### PR TITLE
Submit facts and trusted to get_classified

### DIFF
--- a/lib/puppet/parser/functions/node_info.rb
+++ b/lib/puppet/parser/functions/node_info.rb
@@ -11,17 +11,19 @@ end
 # Retrieves node information to be parsed by 3rd party products
 module Puppet::Parser::Functions
   newfunction(:node_info, type: :rvalue) do |args|
-    raise ArgumentError, 'Function accepts a single String' unless args.length == 1 && args[0].is_a?(String)
 
     node_name = args[0]
+    node_facts = args[1]
+    node_trusted = args[2]
+
     ng = Puppet::Util::Nc_https.new
     # groups = ng.get_groups
 
     ngroups = []
 
     # When querying a specific group
-    if args.length == 1
-      raw = ng.get_classified(node_name)
+    if args.length == 3
+      raw = ng.get_classified(node_name, false, node_facts, node_trusted)
 
       Puppet::Type.type(:node_group)
       Puppet::Type::Node_group::ProviderHttps.instances

--- a/lib/puppet/parser/functions/node_info.rb
+++ b/lib/puppet/parser/functions/node_info.rb
@@ -10,7 +10,10 @@ end
 
 # Retrieves node information to be parsed by 3rd party products
 module Puppet::Parser::Functions
-  newfunction(:node_info, type: :rvalue) do |args|
+  newfunction(:node_info, type: :rvalue) do |args| 
+    raise ArgumentError, 'Function accepts a String (nodename) as first arg' unless args[0].is_a?(String)
+    raise ArgumentError, 'Function accepts a Hash with key "fact" as second arg' unless args[1].is_a?(Hash) and args[1].has_key?('fact')
+    raise ArgumentError, 'Function accepts a Hash with key "trusted" as third arg' unless args[2].is_a?(Hash) and args[2].has_key?('trusted')
 
     node_name = args[0]
     node_facts = args[1]

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -2,7 +2,7 @@
 class node_info (
   Stdlib::Absolutepath $node_info_file = '/tmp/node_info.json',
 ){
-  $node_groups = node_info($trusted['certname'])
+  $node_groups = node_info($trusted['certname'], { 'fact' => $facts }, { 'trusted' => $trusted })
 
   file { $node_info_file :
     ensure  => file,

--- a/templates/node_info.json.epp
+++ b/templates/node_info.json.epp
@@ -1,6 +1,7 @@
 {
   "<%= $::trusted['certname'] -%>": {
     "node_groups": <%= $::node_info::node_groups %>,
+    "environment': <%= $::environment %>,
     "classes": <%= $facts['classes'] %>
   }
 }


### PR DESCRIPTION
This also adds environment to the node_info file.  I would realliy like to be able to include config version as well, but I can live with it if that isn't there.  I see why classes is a fact but for large installations that could create a lot of extra traffic.